### PR TITLE
Add Plausible analytics tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,9 +73,9 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "google-universal" # false (default), "google", "google-universal", "custom"
-  google:
-    tracking_id          :
+  provider               :  "plausible" # false (default), "google", "google-universal", "custom", "plausible"
+  plausible:
+    domain               : "alexandregastonbellegarde.github.io"
 
 
 # Site Author

--- a/_includes/analytics-providers/plausible.html
+++ b/_includes/analytics-providers/plausible.html
@@ -1,0 +1,4 @@
+{% if site.analytics.plausible.domain %}
+<script async defer data-domain="{{ site.analytics.plausible.domain }}" src="https://plausible.io/js/plausible.js"></script>
+{% endif %}
+

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -5,6 +5,8 @@
   {% include /analytics-providers/google.html %}
 {% when "google-universal" %}
   {% include /analytics-providers/google-universal.html %}
+{% when "plausible" %}
+  {% include /analytics-providers/plausible.html %}
 {% when "custom" %}
   {% include /analytics-providers/custom.html %}
 {% endcase %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,4 @@
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
 
-{% include analytics.html %}
 {% include /comments-providers/scripts.html %}
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@ layout: compress
   <head>
     {% include head.html %}
     {% include head/custom.html %}
+    {% include analytics.html %}
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- configure Plausible analytics in site config
- load Plausible script with new include and provider
- move analytics include into default layout

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aeb756bd38832cbb9fa1d83438cbb4