### PR TITLE
Ensure contact form link is visible in navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,13 +7,13 @@ main:
     url: /talks/    
 
   - title: "Enseignements"
-    url: /teaching/    
-    
-  - title: "Portfolio"
-    url: /portfolio/
-   
-  - title: "CV"
-    url: /cv/
-  
+    url: /teaching/
+
   - title: "Formulaire de contact"
     url: /contact/
+
+  - title: "Portfolio"
+    url: /portfolio/
+
+  - title: "CV"
+    url: /cv/


### PR DESCRIPTION
## Summary
- Reorder `_data/navigation.yml` to move contact form link before Portfolio and CV

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aec194a2ec832cba11744937273dc8