### PR TITLE
Add birthdate field to contact form

### DIFF
--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -19,6 +19,9 @@ author_profile: true
     <label for="telephone">Téléphone</label>
     <input type="tel" id="telephone" name="telephone" inputmode="tel" autocomplete="tel">
 
+    <label for="naissance">Date de naissance</label>
+    <input type="date" id="naissance" name="naissance">
+
     <label for="creneau">Date et heure souhaitées</label>
     <input type="datetime-local" id="creneau" name="creneau" required>
 


### PR DESCRIPTION
## Summary
- add birthdate input field to the contact form
- ensure Formspree automatically captures the new field

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aec436f434832ca72c0024a77ce824