### PR TITLE
Afficher le bandeau gauche (profil auteur) sur bilan-qi-paris

### DIFF
--- a/bilan-qi-paris.html
+++ b/bilan-qi-paris.html
@@ -4,7 +4,7 @@ title: "Bilan QI à Paris"
 head_title: "Bilan de QI Adulte et Enfant à Paris | Neuropsychologue"
 description: "Réalisez un bilan de QI (WAIS-IV / WISC-V) à Paris avec Alexandre Gaston-Bellegarde, psychologue spécialisé en neuropsychologie. Détection HPI, adultes et enfants."
 permalink: /bilan-qi-paris.html
-author_profile: false
+author_profile: true
 ---
 
 <section id="bilan-neuropsychologique">


### PR DESCRIPTION
### Motivation
- Permettre l'affichage du bandeau latéral (photo + réseaux) sur la page `bilan-qi-paris.html` en alignant son front matter avec les autres pages.

### Description
- Activation de la propriété `author_profile: true` dans le front matter du fichier `bilan-qi-paris.html` pour afficher le profil auteur et la sidebar associée.

### Testing
- Exécution réussie de la génération locale avec `bundle exec jekyll build`.
- Démarrage du serveur local avec `bundle exec jekyll serve` et vérification visuelle via une capture réalisée par un script Playwright pointant sur `/bilan-qi-paris.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b00b5644832ca24a363bb705db10)