### PR TITLE
Remove consultations CTA from homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -14,11 +14,7 @@ La consultation en neuropsychologie
 ======
 La neuropsychologie est définie comme une discipline qui étudie les perturbations cognitives, comportementales et émotionnelles en lien avec des dysfonctionnements cérébraux. Chez l'enfant et l'adolescent et l'adulte.
 
-[## QUEL TYPE DE BILAN ?](https://alexandregastonbellegarde.github.io//bilan-qi-paris.html)
 
-<a href="https://alexandregastonbellegarde.github.io//bilan-qi-paris.html" style="display:inline-block;padding:14px 20px;background:#0b57d0;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;font-size:0.9rem;white-space:nowrap;">
-  Découvrir mes consultations : Bilans de QI (Enfants/Adultes) et tests attentionnels à Paris
-</a>
 
 
 


### PR DESCRIPTION
### Motivation
- Remove the inline call-to-action linking to the consultations page from the homepage to simplify the page and avoid an external promotional button.

### Description
- Deleted the `## QUEL TYPE DE BILAN ?` anchor and the inline-styled `<a>` CTA button linking to the consultations page from `_pages/about.md`.

### Testing
- Performed a local site build with `jekyll build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9af844618832c8ca2a948ab7799dc)