### PR TITLE
Update consultation psychometric assessment price to 450€

### DIFF
--- a/_pages/consultation.md
+++ b/_pages/consultation.md
@@ -32,7 +32,7 @@ La durée moyenne de prise en charge dans un programme de remédiation cognitive
 
 * <ins>Tarifs</ins> 
 
-  * Bilan psychométrique seul (WPPSI-IV, WISC-V, WAIS IV): 400 €
+  * Bilan psychométrique seul (WPPSI-IV, WISC-V, WAIS IV): 450 €
   * Bilan attentionnel (listes des tests à définir en fonction des besoins et de l'âge): 300 €
   * Bilan neurovisuel - (bilan spécifique pour évaluer la fonction visuelle): 250 €
   * Séance de remédiation cognitive - Enfant/Adulte (60 minutes): 70 €


### PR DESCRIPTION
### Motivation
- Mettre à jour le tarif affiché pour le « Bilan psychométrique seul » sur la page de consultation de 400 € à 450 €.

### Description
- Remplacement de la valeur dans le fichier ` _pages/consultation.md` (remplacement de `400 €` par `450 €`) et commit de la modification (`fa5dec6`).

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification (mise à jour de contenu uniquement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06c05ff08832c85d748f19c8d9114)