### PR TITLE
Fix consultation permalink, remove legacy talks block, and correct contact link

### DIFF
--- a/_pages/consultation.md
+++ b/_pages/consultation.md
@@ -1,7 +1,7 @@
 ---
 layout: archive
 title: "Consultation: qui suis-je ?"
-permalink: /talks/
+permalink: /consultation/
 author_profile: true
 ---
 
@@ -43,13 +43,3 @@ La durée moyenne de prise en charge dans un programme de remédiation cognitive
 
 ---
 
-
-{% if site.talkmap_link == true %}
-
-<p style="text-decoration:underline;"><a href="/talkmap.html">See a map of all the places I've given a talk!</a></p>
-
-{% endif %}
-
-{% for post in site.talks reversed %}
-  {% include archive-single-talk.html %}
-{% endfor %}

--- a/bilan-qi-paris.html
+++ b/bilan-qi-paris.html
@@ -90,7 +90,7 @@ author_profile: true
             <li><strong>Adresse du cabinet :</strong> <address>12 avenue de la Grande Armée, 75017 Paris</address></li>
         </ul>
         <p>
-            <a href="https://alexandregastonbellegarde.github.io//contact/" class="btn btn--primary">PRENDRE rendez-vous</a>
+            <a href="/contact/" class="btn btn--primary">PRENDRE rendez-vous</a>
         </p>
     </section>
 </section>


### PR DESCRIPTION
### Motivation
- Ensure the consultation page uses a clear, SEO-friendly URL by changing its permalink from `/talks/` to `/consultation/`.
- Remove an inherited template fragment that appended unrelated “Talks” content to the consultation page to avoid confusing or irrelevant output.
- Fix a minor URL formatting issue where the contact CTA used an absolute URL with a double slash so the site uses a clean site-relative path.

### Description
- Updated `_pages/consultation.md` to set `permalink: /consultation/` and removed the `talkmap_link` check and the `{% for post in site.talks reversed %}` loop.
- Replaced the contact button href in `bilan-qi-paris.html` from the absolute `https://...//contact/` form to the site-relative `
/contact/`.
- The changes are limited to `_pages/consultation.md` and `bilan-qi-paris.html` and remove only the legacy talk-related Liquid block and the malformed contact URL.

### Testing
- Inspected the repository diffs to confirm only the intended lines in the two target files were changed and the modifications are syntactically valid.
- Verified repository status to ensure no unintended tracked files were modified; an unrelated `node_modules/` directory remains untracked and does not affect the change.
- Recorded the update in the project history and confirmed the file revisions include the new permalink, removed Liquid block, and corrected contact link.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06ccf48a4832cb478d367c5735bf9)