### PR TITLE
Move talks to /talks/, set consultation permalink to /consultation/, and fix contact link

### DIFF
--- a/_pages/consultation.md
+++ b/_pages/consultation.md
@@ -1,7 +1,7 @@
 ---
 layout: archive
 title: "Consultation: qui suis-je ?"
-permalink: /talks/
+permalink: /consultation/
 author_profile: true
 ---
 
@@ -43,13 +43,3 @@ La durée moyenne de prise en charge dans un programme de remédiation cognitive
 
 ---
 
-
-{% if site.talkmap_link == true %}
-
-<p style="text-decoration:underline;"><a href="/talkmap.html">See a map of all the places I've given a talk!</a></p>
-
-{% endif %}
-
-{% for post in site.talks reversed %}
-  {% include archive-single-talk.html %}
-{% endfor %}

--- a/_pages/talks.md
+++ b/_pages/talks.md
@@ -1,0 +1,14 @@
+---
+layout: archive
+title: "Talks"
+permalink: /talks/
+author_profile: true
+---
+
+{% if site.talkmap_link == true %}
+<p style="text-decoration:underline;"><a href="/talkmap.html">See a map of all the places I've given a talk!</a></p>
+{% endif %}
+
+{% for post in site.talks reversed %}
+  {% include archive-single-talk.html %}
+{% endfor %}

--- a/bilan-qi-paris.html
+++ b/bilan-qi-paris.html
@@ -90,7 +90,7 @@ author_profile: true
             <li><strong>Adresse du cabinet :</strong> <address>12 avenue de la Grande Armée, 75017 Paris</address></li>
         </ul>
         <p>
-            <a href="https://alexandregastonbellegarde.github.io//contact/" class="btn btn--primary">PRENDRE rendez-vous</a>
+            <a href="/contact/" class="btn btn--primary">PRENDRE rendez-vous</a>
         </p>
     </section>
 </section>


### PR DESCRIPTION
### Motivation
- Ensure the consultation page has the correct URL and extract the talks archive to its own page so the site structure is consistent and pages don't share the same permalink.
- Remove hardcoded GitHub Pages URL for the contact link to make navigation robust across environments.

### Description
- Updated `_pages/consultation.md` to set `permalink: /consultation/` and removed the embedded talks archive include from the bottom of the page.
- Added a new `_pages/talks.md` file with `permalink: /talks/` which renders the talks archive and the optional talkmap link.
- Changed the appointment button in `bilan-qi-paris.html` from the hardcoded `https://alexandregastonbellegarde.github.io//contact/` to the relative `/contact/` path.

### Testing
- Ran a local site build with `bundle exec jekyll build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06ccf48a4832cb478d367c5735bf9)