### PR TITLE
Replace /talks/ page with consultation content and fix formatting

### DIFF
--- a/_pages/consultation.md
+++ b/_pages/consultation.md
@@ -5,41 +5,36 @@ permalink: /consultation/
 author_profile: true
 ---
 
-
 Je suis diplômé d’un Master 2 Psychologie Cognitive et Neuropsychologie obtenu à l’Université Paris Cité (ex-Descartes) en 2014 et j’exerce actuellement dans le cadre d’une activité libérale.
 
 J’interviens auprès des enfants, des adolescents, des adultes mais également auprès des personnes âgées.
 
-<ins>Mes champs de compétence</ins> 
-  * Bilans neuropsychologiques enfants et adultes.
-  * Entraînement cognitif enfants et adultes: utilisation d'outils innovants (réalité virtuelle, serious game, métacognition, cohérence cardiaque, méditation en pleine conscience...).
-  * Spécialisations: bilan d'efficience intellectuelle (WISC – WPPSI – WAIS), bilan neuropsychologique, bilan attentionnel et exécutif, bilan neurovisuel.
+<ins>Mes champs de compétence</ins>
 
+- Bilans neuropsychologiques enfants et adultes.
+- Entraînement cognitif enfants et adultes : utilisation d'outils innovants (réalité virtuelle, serious game, métacognition, cohérence cardiaque, méditation en pleine conscience...).
+- Spécialisations : bilan d'efficience intellectuelle (WISC – WPPSI – WAIS), bilan neuropsychologique, bilan attentionnel et exécutif, bilan neurovisuel.
 
-<ins>La remédiation cognitive</ins>  est une forme de thérapie visant à diminuer l’impact des difficultés cognitives sur le quotidien d’un patient, objectivées au préalable lors d’un bilan neuropsychologique.
+<ins>La remédiation cognitive</ins> est une forme de thérapie visant à diminuer l’impact des difficultés cognitives sur le quotidien d’un patient, objectivées au préalable lors d’un bilan neuropsychologique.
 
-Il existe deux principales techniques de remédiation cognitive. La première consiste à entrainer de manière intensive la fonction déficitaire (par exemple, s’entrainer à apprendre de nouvelles informations si le patient a des problèmes de mémoire).
+Il existe deux principales techniques de remédiation cognitive. La première consiste à entraîner de manière intensive la fonction déficitaire (par exemple, s’entraîner à apprendre de nouvelles informations si le patient a des problèmes de mémoire).
 
 La seconde consiste à contourner la difficulté, en réfléchissant à des stratégies de compensation s’appuyant sur les capacités préservées du patient (par exemple, noter les informations à retenir, utiliser des moyens mnémotechniques…).
 
-<ins>TDAH : Qu'est-ce qui fonctionne vraiment ? Découvrez-le grâce aux preuves scientifiques.</ins>
+<ins>TDAH : qu'est-ce qui fonctionne vraiment ? Découvrez-le grâce aux preuves scientifiques.</ins>
 
 Entre les médicaments, les thérapies et les nouvelles méthodes, il est parfois difficile de s'y retrouver. Le site EBI-ADHD a été conçu pour simplifier votre parcours. Grâce au tableau de bord interactif, comparez en un coup d'œil l'efficacité des différents traitements pour enfants, adolescents et adultes. La complexité de la recherche médicale est traduite en indicateurs visuels simples : impact sur le cerveau, qualité des preuves et tolérance au traitement. (Le site) : [https://ebiadhd-database.org/fr/dashboard?category=brain](https://ebiadhd-database.org/fr/dashboard?category=brain)
 
-<ins>Durée moyenne de prise en charge en remédiation cognitive</ins> 
+<ins>Durée moyenne de prise en charge en remédiation cognitive</ins>
 
-La durée moyenne de prise en charge dans un programme de remédiation cognitive pour le TDAH, selon les études, varient entre 20 et 30 séances. Cette durée peut varier en fonction des besoins spécifiques de l’individu et de l’intensité du programme de remédiation cognitive mis en place.
+La durée moyenne de prise en charge dans un programme de remédiation cognitive pour le TDAH, selon les études, varie entre 20 et 30 séances. Cette durée peut varier en fonction des besoins spécifiques de l’individu et de l’intensité du programme de remédiation cognitive mis en place.
 
-* <ins>Tarifs</ins> 
+- <ins>Tarifs</ins>
+  - Bilan psychométrique seul (WPPSI-IV, WISC-V, WAIS IV) : 450 €
+  - Bilan attentionnel (liste des tests à définir en fonction des besoins et de l'âge) : 300 €
+  - Bilan neurovisuel (bilan spécifique pour évaluer la fonction visuelle) : 250 €
+  - Séance de remédiation cognitive - Enfant/Adulte (60 minutes) : 70 €
 
-  * Bilan psychométrique seul (WPPSI-IV, WISC-V, WAIS IV): 450 €
-  * Bilan attentionnel (listes des tests à définir en fonction des besoins et de l'âge): 300 €
-  * Bilan neurovisuel - (bilan spécifique pour évaluer la fonction visuelle): 250 €
-  * Séance de remédiation cognitive - Enfant/Adulte (60 minutes): 70 €
- 
 ### Pour prendre rendez-vous : contactez-moi par mail : alexandre.bellegarde@gmail.com
 
-### Mon cabinet de consultation se situe au 12 avenue de la grande armée - 75017 - Paris
-
----
-
+### Mon cabinet de consultation se situe au 12 avenue de la Grande-Armée - 75017 - Paris

--- a/_pages/talks.md
+++ b/_pages/talks.md
@@ -1,14 +1,40 @@
 ---
 layout: archive
-title: "Talks"
+title: "Consultation: qui suis-je ?"
 permalink: /talks/
 author_profile: true
 ---
 
-{% if site.talkmap_link == true %}
-<p style="text-decoration:underline;"><a href="/talkmap.html">See a map of all the places I've given a talk!</a></p>
-{% endif %}
+Je suis diplômé d’un Master 2 Psychologie Cognitive et Neuropsychologie obtenu à l’Université Paris Cité (ex-Descartes) en 2014 et j’exerce actuellement dans le cadre d’une activité libérale.
 
-{% for post in site.talks reversed %}
-  {% include archive-single-talk.html %}
-{% endfor %}
+J’interviens auprès des enfants, des adolescents, des adultes mais également auprès des personnes âgées.
+
+<ins>Mes champs de compétence</ins>
+
+- Bilans neuropsychologiques enfants et adultes.
+- Entraînement cognitif enfants et adultes : utilisation d'outils innovants (réalité virtuelle, serious game, métacognition, cohérence cardiaque, méditation en pleine conscience...).
+- Spécialisations : bilan d'efficience intellectuelle (WISC – WPPSI – WAIS), bilan neuropsychologique, bilan attentionnel et exécutif, bilan neurovisuel.
+
+<ins>La remédiation cognitive</ins> est une forme de thérapie visant à diminuer l’impact des difficultés cognitives sur le quotidien d’un patient, objectivées au préalable lors d’un bilan neuropsychologique.
+
+Il existe deux principales techniques de remédiation cognitive. La première consiste à entraîner de manière intensive la fonction déficitaire (par exemple, s’entraîner à apprendre de nouvelles informations si le patient a des problèmes de mémoire).
+
+La seconde consiste à contourner la difficulté, en réfléchissant à des stratégies de compensation s’appuyant sur les capacités préservées du patient (par exemple, noter les informations à retenir, utiliser des moyens mnémotechniques…).
+
+<ins>TDAH : qu'est-ce qui fonctionne vraiment ? Découvrez-le grâce aux preuves scientifiques.</ins>
+
+Entre les médicaments, les thérapies et les nouvelles méthodes, il est parfois difficile de s'y retrouver. Le site EBI-ADHD a été conçu pour simplifier votre parcours. Grâce au tableau de bord interactif, comparez en un coup d'œil l'efficacité des différents traitements pour enfants, adolescents et adultes. La complexité de la recherche médicale est traduite en indicateurs visuels simples : impact sur le cerveau, qualité des preuves et tolérance au traitement. (Le site) : [https://ebiadhd-database.org/fr/dashboard?category=brain](https://ebiadhd-database.org/fr/dashboard?category=brain)
+
+<ins>Durée moyenne de prise en charge en remédiation cognitive</ins>
+
+La durée moyenne de prise en charge dans un programme de remédiation cognitive pour le TDAH, selon les études, varie entre 20 et 30 séances. Cette durée peut varier en fonction des besoins spécifiques de l’individu et de l’intensité du programme de remédiation cognitive mis en place.
+
+- <ins>Tarifs</ins>
+  - Bilan psychométrique seul (WPPSI-IV, WISC-V, WAIS IV) : 450 €
+  - Bilan attentionnel (liste des tests à définir en fonction des besoins et de l'âge) : 300 €
+  - Bilan neurovisuel (bilan spécifique pour évaluer la fonction visuelle) : 250 €
+  - Séance de remédiation cognitive - Enfant/Adulte (60 minutes) : 70 €
+
+### Pour prendre rendez-vous : contactez-moi par mail : alexandre.bellegarde@gmail.com
+
+### Mon cabinet de consultation se situe au 12 avenue de la Grande-Armée - 75017 - Paris


### PR DESCRIPTION
### Motivation
- Ensure the `/talks/` URL serves the consultation content provided and remove the previous talk listing to match the requested site update. 
- Fix formatting, punctuation and French typographical errors and keep the dedicated `_pages/consultation.md` in sync to avoid content divergence.

### Description
- Replaced the talk listing in `_pages/talks.md` with the consultation text and updated the page `title` to "Consultation: qui suis-je ?" while keeping the `permalink: /talks/` so the URL shows the consultation content. 
- Cleaned and normalized `_pages/consultation.md` front matter and body, correcting punctuation, typographic spacing, list markers and French accents (e.g. `entrainer` → `entraîner`, `varient` → `varie`). 
- Synchronized the corrected consultation content between `_pages/talks.md` and `_pages/consultation.md` to avoid inconsistencies. 
- Changes were staged and committed with the message `Update talks page with consultation content and fix formatting`.

### Testing
- Attempted `bundle exec jekyll build`, which failed because `jekyll` is not installed in the environment. 
- Ran `git status --short`, which executed successfully and showed the modified files. 
- Performed `git commit`, which completed successfully and recorded the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0737646a4832c95e00f582dc785c4)