### PR TITLE
Fix homepage consultation CTA overflow on mobile

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -15,7 +15,7 @@ La consultation en neuropsychologie
 La neuropsychologie est définie comme une discipline qui étudie les perturbations cognitives, comportementales et émotionnelles en lien avec des dysfonctionnements cérébraux. Chez l'enfant et l'adolescent et l'adulte.
 
 
-<a href="https://alexandregastonbellegarde.github.io//bilan-qi-paris.html" style="display:inline-block;padding:14px 20px;margin:8px 0;background:#0b57d0;color:#fff !important;text-decoration:none;border:1px solid #0b57d0;border-radius:8px;font-weight:600;font-size:0.9rem;line-height:1.2;white-space:nowrap;">Découvrir mes consultations : Bilans de QI (Enfants/Adultes) et tests attentionnels à Paris</a>
+<a href="https://alexandregastonbellegarde.github.io//bilan-qi-paris.html" style="display:inline-block;max-width:100%;box-sizing:border-box;padding:14px 20px;margin:8px 0;background:#0b57d0;color:#fff !important;text-decoration:none;border:1px solid #0b57d0;border-radius:8px;font-weight:600;font-size:0.9rem;line-height:1.2;white-space:normal;overflow-wrap:anywhere;">Découvrir mes consultations : Bilans de QI (Enfants/Adultes) et tests attentionnels à Paris</a>
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent the homepage call-to-action link from overflowing on small/mobile screens by allowing the button text to wrap and constraining its width.

### Description
- Update the inline style on the homepage CTA in `_pages/about.md` to remove `white-space:nowrap` and add `max-width:100%`, `box-sizing:border-box`, `white-space:normal`, and `overflow-wrap:anywhere` so the link becomes responsive.

### Testing
- Ran `bundle exec jekyll build`, which failed due to a missing `jekyll` executable in the environment (`bundler: command not found: jekyll`), so no successful site build was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f074d5d1cc832c99cfde6d3ef524f3)